### PR TITLE
Make ikiwiki not puke on the plugin so badly

### DIFF
--- a/mediawiki.pm
+++ b/mediawiki.pm
@@ -59,7 +59,7 @@ sub import { #{{{
 
 sub checkconfig
 {
-	return IkiWiki::Plugin::link::checkconfig(@_);
+	return IkiWiki::Plugin::link::checkconfig();
 }
 
 


### PR DESCRIPTION
This plugin doesn't currently work with ikiwiki-3, and this patch will help it not throw such a terrible, terrible error message. But so far the output is not very appealing.
